### PR TITLE
Añadido workflow para github pages

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,52 @@
+name: Deploy to pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    # Runs on ubuntu with node 18
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18]
+    name: Node ${{ matrix.node }} sample
+    steps:
+      # Pulls the repository
+      - uses: actions/checkout@v3
+      # Sets up node
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      # Installs dependencies and builds
+      - run: npm install
+      - run: npm run build
+      # Uploads the build directory as an artifact (specifically a "pages" artifact)
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+
+  # Deploy job
+  deploy:
+    # Add a dependency to the build job
+    needs: build
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2 # or the latest "vX.X.X" version tag for this action

--- a/src/components/CreateTodo.vue
+++ b/src/components/CreateTodo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Todo, TodoStatus } from "src/types.ts";
+import type { Todo, TodoStatus } from "src/types";
 import { reactive, ref } from "vue";
 import useTodos from "@/store/useTodos";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
-  }
+  },
+  base: '/todo-list/'
 })


### PR DESCRIPTION
Añadida configuración para hacer deploy automáticamente a github pages.
Es posible que necesites cambiar la configuración del repo para que funcione (Settings > Pages > Build and deployment > Source -> Github pages)

Inspirado de https://github.com/actions/deploy-pages y https://github.com/actions/upload-pages-artifact

Una vez esté mergeado a main debería de tardar 1 o 2 minutos en lanzar la build a https://alvaro219.github.io/todo-list/